### PR TITLE
fix: implement use of Molgenis EMX2 Pyclient for importing data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Unidecode~=1.3.8
 requests~=2.32.3
 click~=8.1.8
 molgenis-emx2-pyclient>=11.57.0
+python-dotenv~=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+rdflib~=7.1.3
+geomet~=1.1.0
+Unidecode~=1.3.8
+requests~=2.32.3
+click~=8.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ geomet~=1.1.0
 Unidecode~=1.3.8
 requests~=2.32.3
 click~=8.1.8
+molgenis-emx2-pyclient>=11.57.0

--- a/src/molgenis_fdp_harvester/ckan_harvest/baseharvester.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/baseharvester.py
@@ -14,7 +14,7 @@ import re
 
 from unidecode import unidecode
 
-from molgenis_fdp_harvester.ckan_harvest.baseparser import (
+from .baseparser import (
     _munge_to_length,
     munge_tag,
 )

--- a/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
@@ -296,7 +296,6 @@ class DCATRDFHarvester(DCATHarvester):
                 molgenis_client.update_all(self.entity_name, [dataset])
             else:
                 log.info("Adding dataset %s" % dataset["name"])
-                molgenis_client.add(self.entity_name, dataset)
                 molgenis_client.save_schema(table=self.entity_name, data=[dataset])
         except Exception as e:
             log.error(

--- a/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
@@ -293,7 +293,7 @@ class DCATRDFHarvester(DCATHarvester):
         try:
             if harvest_object.guid in self._existing_dataset_guid:
                 log.info("Updating dataset %s" % dataset["name"])
-                molgenis_client.update_all(self.entity_name, [dataset])
+                molgenis_client.save_schema(table=self.entity_name, data=[dataset])
             else:
                 log.info("Adding dataset %s" % dataset["name"])
                 molgenis_client.save_schema(table=self.entity_name, data=[dataset])

--- a/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
@@ -17,9 +17,8 @@ from typing import List
 import logging
 import hashlib
 import traceback
-
-from molgenis_fdp_harvester.ckan_harvest.baseharvester import munge_title_to_name
-from molgenis.client import Session
+from molgenis_emx2_pyclient import Client
+from .baseharvester import munge_title_to_name
 
 
 # import ckan.plugins as p
@@ -248,11 +247,11 @@ class DCATRDFHarvester(DCATHarvester):
 
         return self._harvest_objects
 
-    def fetch_stage(self, molgenis_session: Session) -> List[str]:
+    def fetch_stage(self, molgenis_client: Client) -> List[str]:
         # Reusing the fetch stage to get a list of IDs
         # Note: very specific to current EUCAIM collections
         try:
-            existing_ids = molgenis_session.get(self.entity_name)
+            existing_ids = molgenis_client.get(self.entity_name)
             self._existing_dataset_guid = [x["id"] for x in existing_ids]
         except Exception as e:
             log.error(
@@ -263,7 +262,7 @@ class DCATRDFHarvester(DCATHarvester):
 
         return self._existing_dataset_guid
 
-    def import_stage(self, harvest_object: HarvestObject, molgenis_session: Session):
+    def import_stage(self, harvest_object: HarvestObject, molgenis_client: Client):
 
         log.debug("In DCATRDFHarvester import_stage")
 
@@ -294,10 +293,11 @@ class DCATRDFHarvester(DCATHarvester):
         try:
             if harvest_object.guid in self._existing_dataset_guid:
                 log.info("Updating dataset %s" % dataset["name"])
-                molgenis_session.update_all(self.entity_name, [dataset])
+                molgenis_client.update_all(self.entity_name, [dataset])
             else:
                 log.info("Adding dataset %s" % dataset["name"])
-                molgenis_session.add(self.entity_name, dataset)
+                molgenis_client.add(self.entity_name, dataset)
+                molgenis_client.save_schema(table=self.entity_name, data=[dataset])
         except Exception as e:
             log.error(
                 "import_stage: Error importing dataset %s: %r / %s"

--- a/src/molgenis_fdp_harvester/ckan_harvest/processor.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/processor.py
@@ -15,7 +15,7 @@ import rdflib
 import rdflib.parser
 from rdflib.namespace import Namespace, RDF, DCAT
 
-from molgenis_fdp_harvester.utils import HarvesterException
+from src.molgenis_fdp_harvester.utils import HarvesterException
 
 
 HYDRA = Namespace("http://www.w3.org/ns/hydra/core#")

--- a/src/molgenis_fdp_harvester/harvester.py
+++ b/src/molgenis_fdp_harvester/harvester.py
@@ -2,12 +2,18 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-Create a token on the host MOLGENIS server and store this token as an environment variable named MOLGENIS_TOKEN:
+Create a token on the host MOLGENIS server and store this token as an environment variable named MOLGENIS_TOKEN,
+either by creating a .env file in the working directory containing the single line
+MOLGENIS_TOKEN="..."
+or by directly exporting the token to the working environment
 $ export MOLGENIS_TOKEN="..."
+The user creating this token requires editing permissions on the host schema.
 """
+import logging
 import os
 
 import click
+from dotenv import load_dotenv
 from molgenis_emx2_pyclient import Client
 
 from ckan_harvest.dcatrdfharvester import DCATRDFHarvester
@@ -15,6 +21,8 @@ from ckan_harvest.molgenis_dcat_profile import (
     MolgenisEUCAIMDCATAPProfile,
 )
 
+load_dotenv()
+logging.basicConfig(level="INFO")
 
 @click.command()
 @click.option("--fdp", help="FAIR Data Point catalog URL to harvest", required=True)
@@ -23,7 +31,7 @@ from ckan_harvest.molgenis_dcat_profile import (
               required=False, default="Eucaim")
 @click.option(
     "--table",
-    help="Table of MOLGENIS host to harvest to (e.g. EUCAIM_collections)",
+    help="Table of MOLGENIS host to harvest to.",
     required=False,
     default="collections"
 )

--- a/src/molgenis_fdp_harvester/harvester.py
+++ b/src/molgenis_fdp_harvester/harvester.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import click
+from molgenis_emx2_pyclient import Client
 
-from molgenis_fdp_harvester.ckan_harvest.dcatrdfharvester import DCATRDFHarvester
-from molgenis_fdp_harvester.ckan_harvest.molgenis_dcat_profile import (
+from ckan_harvest.dcatrdfharvester import DCATRDFHarvester
+from ckan_harvest.molgenis_dcat_profile import (
     MolgenisEUCAIMDCATAPProfile,
 )
-import molgenis.client
 
 
 @click.command()
@@ -29,17 +29,15 @@ def cli(
     username: str,
     password: str,
 ):
-    molgenis_session = molgenis.client.Session(host)
-    molgenis_session.login(username, password)
-
     harvest = DCATRDFHarvester([MolgenisEUCAIMDCATAPProfile], entity)
 
     harvest.gather_stage(fdp)
-    # for object in harvest._harvest_objects:
-    #     print(object.content)
-    harvest.fetch_stage(molgenis_session)
-    for object in harvest._harvest_objects:
-        harvest.import_stage(object, molgenis_session)
+
+    with Client(url=host, schema="Eucaim") as client:
+        client.signin(username, password)
+        harvest.fetch_stage(client)
+        for object in harvest._harvest_objects:
+            harvest.import_stage(object, client)
 
 
 if __name__ == "__main__":

--- a/src/molgenis_fdp_harvester/harvester.py
+++ b/src/molgenis_fdp_harvester/harvester.py
@@ -1,6 +1,12 @@
 # SPDX-FileCopyrightText: 2024-present Mark Janse <mark.janse@health-ri.nl>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Create a token on the host MOLGENIS server and store this token as an environment variable named MOLGENIS_TOKEN:
+$ export MOLGENIS_TOKEN="..."
+"""
+import os
+
 import click
 from molgenis_emx2_pyclient import Client
 
@@ -11,30 +17,34 @@ from ckan_harvest.molgenis_dcat_profile import (
 
 
 @click.command()
-@click.option("--fdp", help="FAIR Data Point catalog to harvest", required=True)
-@click.option("--host", help="MOLGENIS host to harvest to", required=False)
+@click.option("--fdp", help="FAIR Data Point catalog URL to harvest", required=True)
+@click.option("--host", help="MOLGENIS host to harvest to", required=True)
+@click.option("--schema", help="Schema on MOLGENIS host to harvest to",
+              required=False, default="Eucaim")
 @click.option(
-    "--entity",
-    help="Entity of MOLGENIS host to harvest to (e.g. EUCAIM_collections)",
+    "--table",
+    help="Table of MOLGENIS host to harvest to (e.g. EUCAIM_collections)",
     required=False,
+    default="collections"
 )
 @click.option(
-    "--username", help="Username of MOLGENIS host to harvest to", required=False
+    "--token", help="Authentication token of the user harvesting data.",
+    required=False, default=os.environ.get("MOLGENIS_TOKEN")
 )
-@click.password_option(confirmation_prompt=False, required=False)
+
+
 def cli(
     fdp: str,
     host: str,
-    entity: str,
-    username: str,
-    password: str,
+    schema: str,
+    table: str,
+    token: str,
 ):
-    harvest = DCATRDFHarvester([MolgenisEUCAIMDCATAPProfile], entity)
+    harvest = DCATRDFHarvester([MolgenisEUCAIMDCATAPProfile], table)
 
     harvest.gather_stage(fdp)
 
-    with Client(url=host, schema="Eucaim") as client:
-        client.signin(username, password)
+    with Client(url=host, schema=schema, token=token) as client:
         harvest.fetch_stage(client)
         for object in harvest._harvest_objects:
             harvest.import_stage(object, client)


### PR DESCRIPTION
The EUCAIM catalogue is hosted on an EMX2 server for which the [Molgenis EMX2 Pyclient](https://pypi.org/project/molgenis-emx2-pyclient/) is developed.

There are differences in the functionality of the EMX2 Pyclient and the Python client written for EMX1. These changes need to be addressed in this package in order for the FDP harvester to function on the EUCAIM catalogue server.

Full documentation of the Pyclient is available [here](https://molgenis.github.io/molgenis-emx2/#/molgenis/use_usingpyclient)

To do's:

- [x] replace calls to the EMX1 client/session to Pyclient
- [x] replace `update_all` functionality by new Pyclient functionality
- [x] replace `add` functionality by new Pyclient functionality
- [x] improve authorization process