### PR TITLE
Harvest Datasets, Dataset Series and Persons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,47 @@
 # MOLGENIS FDP Harvester
 
-[![PyPI - Version](https://img.shields.io/pypi/v/molgenis-fdp-harvester.svg)](https://pypi.org/project/molgenis-fdp-harvester)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/molgenis-fdp-harvester.svg)](https://pypi.org/project/molgenis-fdp-harvester)
-
 -----
-
-## Table of Contents**
-
-- [Installation](#installation)
-- [License](#license)
 
 ## Installation
 
 ```console
-pip install molgenis-fdp-harvester
+git clone https://github.com/Health-RI/molgenis-fdp-harvester.git
+cd molgenis-fdp-harvester
+pip install .
 ```
+
+## Usage
+
+```console
+Usage: harvest [OPTIONS]
+
+Options:
+  --fdp TEXT     FAIR Data Point catalog URL to harvest  [required]
+  --host TEXT    MOLGENIS host to harvest to  [required]
+  --schema TEXT  Schema on MOLGENIS host to harvest to
+  --config PATH  Configuration.  [required]
+  --token TEXT   Authentication token of the user harvesting data.
+  --help         Show this message and exit.
+```
+The configuration contains a linking table between the concept types, used internally in the script to separate the
+handling of the different concepts, and the table in the harvesting MOLGENIS catalogue.
+
+## Workings
+
+This harvester is an adaptation of the [CKAN DCAT harvester](https://github.com/ckan/ckanext-dcat). 
+In this harvester the method `DCATRDFHarvester.gather_stage()` is used to first load the RDF data from the FAIR Data 
+Point into a graph using `rdflib` and an `RDFParser` object. After that the datasets, datasetseries and persons are 
+retrieved from the graph and parsed by the profile `MolgenisEUCAIMDCATAPProfile`, using the methods 
+`RDFParser.datatsets()`, `RDFParser.datasetseries()`, and `RDFParser.persons()` respectively. The gather stage
+ends with the creation of a list of `HarvestObject`s. With `DCATRDFHarvester.fetch_stage()`, it is checked if 
+the IDs of the concepts are unique. In the `DCATRDFHarvester.harvest_stage()` method the API calls to the harvesting
+MOLGENIS catalogue are made.
+
+This harvester is tested on https://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf, where the metadata is shown
+on one big page. In other FAIR Data Points multiple links need to be traversed to for example get the dataset metadata. 
+The harvester has not been tested with those kinds of FAIR Data Points.
+
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Point into a graph using `rdflib` and an `RDFParser` object. After that the data
 retrieved from the graph and parsed by the profile `MolgenisEUCAIMDCATAPProfile`, using the methods 
 `RDFParser.datatsets()`, `RDFParser.datasetseries()`, and `RDFParser.persons()` respectively. The gather stage
 ends with the creation of a list of `HarvestObject`s. With `DCATRDFHarvester.fetch_stage()`, it is checked if 
-the IDs of the concepts are unique. In the `DCATRDFHarvester.harvest_stage()` method the API calls to the harvesting
+the IDs of the concepts are unique. In the `DCATRDFHarvester.import_stage()` method the API calls to the harvesting
 MOLGENIS catalogue are made.
 
 This harvester is tested on https://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf, where the metadata is shown

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,4 @@
+[concept_table_link]
+dataset = "collections"
+datasetseries = "biobanks"
+person = "persons"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,15 @@ build-backend = "hatchling.build"
 
 [project]
 dependencies = [
-  "click",
-  "rdflib",
-  "python-dateutil",
-  "pandas",
-  "geomet",
-  "requests",
-  "molgenis-py-client",
-  "unidecode"
+  "click~=8.1.8",
+  "rdflib~=7.1.3",
+  "python-dateutil~=2.9.0.post0",
+  "pandas~=2.2.3",
+  "geomet~=1.1.0",
+  "requests~=2.32.3",
+  "molgenis-emx2-pyclient>=11.57.0",
+  "unidecode~=1.3.8",
+  "python-dotenv~=1.0.1"
 ]
 name = "molgenis-fdp-harvester"
 dynamic = ["version"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-rdflib~=7.1.3
-geomet~=1.1.0
-Unidecode~=1.3.8
-requests~=2.32.3
-click~=8.1.8
-molgenis-emx2-pyclient>=11.57.0
-python-dotenv~=1.0.1

--- a/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
@@ -13,7 +13,7 @@ from builtins import str
 
 # from past.builtins import basestring
 import json
-from typing import List
+from typing import List, Dict
 import logging
 import hashlib
 import traceback
@@ -122,9 +122,9 @@ class DCATRDFHarvester(DCATHarvester):
         # Get file contents of first page
         next_page_url = harvest_root_uri
 
-        guids_in_source = []
+        guids_in_source = {'dataset': [], 'datasetseries': [], 'person': []}
         last_content_hash = None
-        self._names_taken = []
+        self._names_taken = {'dataset': [], 'datasetseries': [], 'person': []}
 
         parser = RDFParser(self._profiles)
 
@@ -168,20 +168,22 @@ class DCATRDFHarvester(DCATHarvester):
             if not parser:
                 return []
 
-            try:
-                # Data
-                for dataset in parser.dataset_in_catalog():
-                    # get content
-                    dataset_content, dataset_rdf_format = self._get_content_and_type(
-                        dataset, 1, content_type=None
-                    )
-                    parser.parse(dataset_content, _format=dataset_rdf_format)
-            except HarvesterException as e:
-                self._save_gather_error(
-                    "Error parsing the acquired dataset: {0}".format(e),
-                )
-                # return []
-                break
+            # Data
+            # try:
+            #     # Data
+            #     for dataset in parser.dataset_in_catalog():
+            #         print(dataset)
+            #         # get content
+            #         dataset_content, dataset_rdf_format = self._get_content_and_type(
+            #             dataset, 1, content_type=None
+            #         )
+            #         parser.parse(dataset_content, _format=dataset_rdf_format)
+            # except HarvesterException as e:
+            #     self._save_gather_error(
+            #         "Error parsing the acquired dataset: {0}".format(e),
+            #     )
+            #     # return []
+            #     break
 
             # get the next page
             # FIXME: separate this out now that parser is global (else it'll always return a next page that isn't necessarily THE next page)
@@ -189,50 +191,12 @@ class DCATRDFHarvester(DCATHarvester):
 
         try:
             # source_dataset = model.Package.get(harvest_job.source.id)
+            for person in parser.persons():
+                guids_in_source =  self._gather_concept(person, guids_in_source, concept_type='person')
+            for dataset_series in parser.datasetseries():
+                guids_in_source =  self._gather_concept(dataset_series, guids_in_source, concept_type='datasetseries')
             for dataset in parser.datasets():
-                if not dataset.get("name"):
-                    dataset["name"] = self._gen_new_name(dataset["title"])
-                if dataset["name"] in self._names_taken:
-                    suffix = (
-                        len(
-                            [
-                                i
-                                for i in self._names_taken
-                                if i.startswith(dataset["name"] + "-")
-                            ]
-                        )
-                        + 1
-                    )
-                    dataset["name"] = "{}-{}".format(dataset["name"], suffix)
-                self._names_taken.append(dataset["name"])
-
-                # Unless already set by the parser, get the owner organization (if any)
-                # from the harvest source dataset
-                # if not dataset.get("owner_org"):
-                #     if source_dataset.owner_org:
-                #         dataset["owner_org"] = source_dataset.owner_org
-
-                # Try to get a unique identifier for the harvested dataset
-                guid = self._get_guid(dataset, source_url=dataset["uri"])
-
-                # FIXME molgenis ID cannot be URI but has to be alphanumeric string
-                dataset["id"] = munge_title_to_name(guid)
-                # dataset["extras"].append({"key": "guid", "value": guid})
-
-                if not guid:
-                    self._save_gather_error(
-                        "Could not get a unique identifier for dataset: {0}".format(
-                            dataset
-                        ),
-                        # harvest_job,
-                    )
-                    continue
-
-                guids_in_source.append(guid)
-
-                obj = HarvestObject(guid=dataset["id"], content=json.dumps(dataset))
-
-                self._harvest_objects.append(obj)
+                guids_in_source =  self._gather_concept(dataset, guids_in_source, concept_type='dataset')
         except Exception as e:
             self._save_gather_error(
                 "Error when processsing dataset: %r / %s" % (e, traceback.format_exc()),
@@ -247,6 +211,53 @@ class DCATRDFHarvester(DCATHarvester):
         # object_ids.extend(object_ids_to_delete)
 
         return self._harvest_objects
+
+    def _gather_concept(self, concept_dict: Dict, guids_in_source: Dict, concept_type: str):
+        if not concept_dict.get("name"):
+                concept_dict["name"] = self._gen_new_name(concept_dict["title"])
+        if concept_dict["name"] in self._names_taken[concept_type]:
+            suffix = (
+                    len(
+                        [
+                            i
+                            for i in self._names_taken
+                            if i.startswith(concept_dict["name"] + "-")
+                        ]
+                    )
+                    + 1
+            )
+            concept_dict["name"] = "{}-{}".format(concept_dict["name"], suffix)
+        self._names_taken[concept_type].append(concept_dict["name"])
+
+        # Unless already set by the parser, get the owner organization (if any)
+        # from the harvest source dataset
+        # if not dataset.get("owner_org"):
+        #     if source_dataset.owner_org:
+        #         dataset["owner_org"] = source_dataset.owner_org
+
+        # Try to get a unique identifier for the harvested dataset
+        guid = self._get_guid(concept_dict, source_url=concept_dict["uri"])
+
+        # FIXME molgenis ID cannot be URI but has to be alphanumeric string
+        concept_dict["id"] = munge_title_to_name(guid)
+        # dataset["extras"].append({"key": "guid", "value": guid})
+
+        if not guid:
+            self._save_gather_error(
+                "Could not get a unique identifier for {0}: {1}".format(
+                    concept_type,
+                    concept_dict
+                ),
+                # harvest_job,
+            )
+            return guids_in_source
+
+        guids_in_source[concept_type].append(guid)
+
+        obj = HarvestObject(guid=concept_dict["id"], content=json.dumps(concept_dict))
+
+        self._harvest_objects.append(obj)
+        return guids_in_source
 
     # def fetch_stage(self, molgenis_session: Session) -> List[str]:
     def fetch_stage(self) -> List[str]:

--- a/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
@@ -248,7 +248,9 @@ class DCATRDFHarvester(DCATHarvester):
 
         return self._harvest_objects
 
-    def fetch_stage(self, molgenis_session: Session) -> List[str]:
+    # def fetch_stage(self, molgenis_session: Session) -> List[str]:
+    def fetch_stage(self) -> List[str]:
+
         # Reusing the fetch stage to get a list of IDs
         # Note: very specific to current EUCAIM collections
         try:
@@ -289,6 +291,7 @@ class DCATRDFHarvester(DCATHarvester):
             return False
 
         dataset = self.modify_package_dict(dataset, {}, harvest_object)
+
 
         # Check if a dataset with the same guid exists
         try:

--- a/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
@@ -261,7 +261,6 @@ class DCATRDFHarvester(DCATHarvester):
         self._harvest_objects.append(obj)
         return guids_in_source
 
-    #def fetch_stage(self, molgenis_client: Client) -> List[str]:
     def fetch_stage(self, molgenis_client: Client) -> None:
         # Reusing the fetch stage to get a list of IDs
         # Note: very specific to current EUCAIM collections
@@ -277,7 +276,6 @@ class DCATRDFHarvester(DCATHarvester):
                 )
                 self._existing_dataset_guid[concept_type] = []
         return
-        # return self._existing_dataset_guid
 
     def import_stage(self, harvest_object: HarvestObject, molgenis_client: Client):
 

--- a/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/dcatrdfharvester.py
@@ -50,15 +50,12 @@ class HarvestObject(object):
 class DCATRDFHarvester(DCATHarvester):
     _names_taken = []
 
-    def __init__(self, profiles: List, entity_name: str):
+    def __init__(self, profiles: List, concept_table_dict: Dict[str, str]):
         super().__init__()
         self._existing_dataset_guid = dict()
         self._profiles = profiles
-        self.entity_name = entity_name
-        self.concept_table_link = {'dataset': 'collections',
-                                   'datasetseries': 'biobanks',
-                                   'person': 'persons'}
-        self.concept_types = ['dataset', 'datasetseries', 'person']
+        self.concept_table_link = concept_table_dict
+        self.concept_types = [concept for concept in self.concept_table_link.keys()]
 
     def info(self):
         return {
@@ -125,9 +122,9 @@ class DCATRDFHarvester(DCATHarvester):
         # Get file contents of first page
         next_page_url = harvest_root_uri
 
-        guids_in_source = {'dataset': [], 'datasetseries': [], 'person': []}
+        guids_in_source = {concept : list() for concept in self.concept_types}
         last_content_hash = None
-        self._names_taken = {'dataset': [], 'datasetseries': [], 'person': []}
+        self._names_taken = {concept : list() for concept in self.concept_types}
 
         parser = RDFParser(self._profiles)
 

--- a/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
@@ -8,7 +8,7 @@
 #
 # Modified by Stichting Health-RI to remove dependencies on CKAN
 
-from typing import Dict
+from typing import Dict, Union
 
 from rdflib import URIRef, FOAF
 from yarl import URL
@@ -50,13 +50,34 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
     https://joinup.ec.europa.eu/asset/dcat_application_profile
 
     """
+    def _extract_name_from_query(self, value: Union[list, str]):
+        if isinstance(value, list):
+            value = [URL(val).query.get('name') for val in value]
+        else:
+            value = URL(value).query.get('name')
+        return value
+
+    def _extract_concept_dict(self, concept_ref, concept_dict: Dict, key_predicate_tuple: tuple, query_property_list: list):
+        for key, predicate in key_predicate_tuple:
+            value = self._object_value(concept_ref, predicate)
+            if len(value) == 1:
+                value = value[0]
+            if value:
+                if key in query_property_list:
+                    value = self._extract_name_from_query(value)
+                if isinstance(value, list):
+                    value = ",".join(value)
+                concept_dict[key] = value
+        return concept_dict
 
     def parse_dataset(self, dataset_dict: Dict, dataset_ref: URIRef):
         # dataset_dict["extras"] = []
         # dataset_dict["resources"] = []
         dataset_dict["uri"] = str(dataset_ref)
         # Basic fields
-        for key, predicate in (
+        query_property_list = ['order_of_magnitude', 'imaging_modality','geographical_coverage','type',
+                               'image_access_type', 'collection_method']
+        key_predicate_tuple = (
             # ("id", DCT.identifier),
             ("name", DCT.title),
             ("description", DCT.description),
@@ -70,10 +91,8 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
             ("image_access_type",
              URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_type")),
             ("collection_method", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/collection_method"))
-        ):
-            value = self._object_value(dataset_ref, predicate)
-            if value:
-                dataset_dict[key] = value
+        )
+        dataset_dict = self._extract_dataset_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
 
         # TODO store keywords somewhere
         # replace munge_tag to noop if there's no need to clean tags
@@ -89,10 +108,7 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
 
         # dataset_dict["biobank"] = URL(dataset_dict["biobank"]).query.get('id')
         dataset_dict["biobank"] = munge_title_to_name(dataset_dict["biobank"])
-        query_property_list = ['order_of_magnitude', 'imaging_modality','geographical_coverage','type',
-                               'image_access_type', 'collection_method']
-        for query_property in query_property_list:
-           dataset_dict[query_property] = URL(dataset_dict[query_property]).query.get('name')
+
 
         return dataset_dict
 
@@ -101,16 +117,19 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         # dataset_dict["resources"] = []
         dataset_dict["uri"] = str(dataset_ref)
         # Basic fields
-        for key, predicate in (
-                # ("id", DCT.identifier),
-                ("name", DCT.title),
-                ("description", DCT.description),
-                ("geographical_coverage", DCT.spatial),
-                ("juridical_person", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/juridical_person")),
-        ):
-            value = self._object_value(dataset_ref, predicate)
-            if value:
-                dataset_dict[key] = value
+        key_predicate_tuple = (
+            # ("id", DCT.identifier),
+            ("name", DCT.title),
+            ("description", DCT.description),
+            ("geographical_coverage", DCT.spatial),
+            ("juridical_person", DCT.publisher),
+            ("url", DCAT.landingPage),
+            ("contact", DCAT.contactPoint),
+            ("network", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/network")),
+            ("withdrawn", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/withdrawn")),
+        )
+        query_property_list = ['geographical_coverage']
+        dataset_dict = self._extract_dataset_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
 
         # # TODO store keywords somewhere
         # # replace munge_tag to noop if there's no need to clean tags
@@ -124,9 +143,11 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         # # These values are fake. They need to be made "real"
         # # log.warning("Filling in fake values")
 
-        query_property_list = ['geographical_coverage']
-        for query_property in query_property_list:
-            dataset_dict[query_property] = URL(dataset_dict[query_property]).query.get('name')
+        try:
+            dataset_dict["contact"] = URL(dataset_dict["contact"]).query.get('id')
+        except KeyError:
+            pass
+        dataset_dict["network"] = URL(dataset_dict["network"]).query.get('id')
 
         return dataset_dict
 
@@ -135,21 +156,17 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         # dataset_dict["resources"] = []
         dataset_dict["uri"] = str(dataset_ref)
         # Basic fields
-        for key, predicate in (
-                ("id", FOAF.openid),
-                ("name", FOAF.openid),
-                ("email", FOAF.mbox),
-                ("first_name", FOAF.firstName),
-                ("last_name", FOAF.lastName),
-                ("country", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/country")),
-        ):
-            value = self._object_value(dataset_ref, predicate)
-            if value:
-                dataset_dict[key] = value
-
+        key_predicate_tuple = (
+            ("id", FOAF.openid),
+            ("name", FOAF.openid),
+            ("email", FOAF.mbox),
+            ("first_name", FOAF.firstName),
+            ("last_name", FOAF.lastName),
+            ("country", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/country")),
+        )
         query_property_list = ['country']
-        for query_property in query_property_list:
-            dataset_dict[query_property] = URL(dataset_dict[query_property]).query.get('name')
+        dataset_dict = self._extract_dataset_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
+
         dataset_dict["email"] = dataset_dict["email"].removeprefix("mailto:")
         return dataset_dict
 

--- a/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
@@ -11,7 +11,7 @@ from urllib import parse
 
 from typing import Dict
 
-from rdflib import URIRef
+from rdflib import URIRef, FOAF
 
 import logging
 
@@ -92,6 +92,62 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         # dataset_dict["image_access_type"] = "BY_REQUEST"
         # dataset_dict["intended_purpose"] = "placeholder"
 
+        return dataset_dict
+
+    def parse_datasetseries(self, dataset_dict: Dict, dataset_ref: URIRef):
+        # dataset_dict["extras"] = []
+        # dataset_dict["resources"] = []
+        dataset_dict["uri"] = str(dataset_ref)
+        # Basic fields
+        for key, predicate in (
+                ("id", DCT.identifier),
+                ("name", DCT.title),
+                ("description", DCT.description),
+        ):
+            value = self._object_value(dataset_ref, predicate)
+            if value:
+                dataset_dict[key] = value
+
+        # # TODO store keywords somewhere
+        # # replace munge_tag to noop if there's no need to clean tags
+        # do_clean = DCAT_CLEAN_TAGS
+        # tags_val = [
+        #     munge_tag(tag) if do_clean else tag for tag in self._keywords(dataset_ref)
+        # ]
+        # tags = [{"name": tag} for tag in tags_val]
+        # # dataset_dict["tags"] = tags
+
+        # # These values are fake. They need to be made "real"
+        # # log.warning("Filling in fake values")
+
+        # # FIXME: Find out how to properly do the query splitting
+        # series_url = parse.urlparse(dataset_dict["biobank"])
+        # dataset_dict["biobank"] = series_url.query.split('=')[1]
+        # print(dataset_dict)
+        # # dataset_dict["biobank"] = "CHAI-4"
+        # # dataset_dict["provider"] = "CHAIMELEON"
+        # # dataset_dict["order_of_magnitude"] = 1
+        # # dataset_dict["country"] = "EU"
+        # # dataset_dict["collection_method"] = "OTHER"
+        # # dataset_dict["type"] = "ORIGINAL_DATASETS"
+        # # dataset_dict["imaging_modality"] = "MR"
+        # # dataset_dict["image_access_type"] = "BY_REQUEST"
+        # # dataset_dict["intended_purpose"] = "placeholder"
+
+        return dataset_dict
+
+    def parse_person(self, dataset_dict: Dict, dataset_ref: URIRef):
+        # dataset_dict["extras"] = []
+        # dataset_dict["resources"] = []
+        dataset_dict["uri"] = str(dataset_ref)
+        # Basic fields
+        for key, predicate in (
+                ("id", FOAF.openid),
+                ("name", FOAF.openid),
+        ):
+            value = self._object_value(dataset_ref, predicate)
+            if value:
+                dataset_dict[key] = value
         return dataset_dict
 
     def graph_from_dataset(self, dataset_dict, dataset_ref):

--- a/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-FileContributor: Stichting Health-RI
-
+from urllib import parse
 # This material is copyright (c) Open Knowledge.
 # It is open and licensed under the GNU Affero General Public License (AGPL) v3.0
 # Original location of file: https://raw.githubusercontent.com/ckan/ckanext-dcat/master/ckanext/dcat/profiles/euro_dcat_ap.py
@@ -28,7 +28,7 @@ import logging
 # )
 from .baseparser import RDFProfile, munge_tag
 from .baseparser import (
-    DCT,
+    DCT, DCAT
 )
 
 log = logging.getLogger(__name__)
@@ -57,8 +57,10 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         dataset_dict["uri"] = str(dataset_ref)
         # Basic fields
         for key, predicate in (
+            ("id", DCT.identifier),
             ("name", DCT.title),
             ("description", DCT.description),
+            ("biobank", DCAT.inSeries),
         ):
             value = self._object_value(dataset_ref, predicate)
             if value:
@@ -74,16 +76,21 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         # dataset_dict["tags"] = tags
 
         # These values are fake. They need to be made "real"
-        log.warning("Filling in fake values")
-        dataset_dict["biobank"] = "CHAI-4"
-        dataset_dict["provider"] = "CHAIMELEON"
-        dataset_dict["order_of_magnitude"] = 1
-        dataset_dict["country"] = "EU"
-        dataset_dict["collection_method"] = "OTHER"
-        dataset_dict["type"] = "ORIGINAL_DATASETS"
-        dataset_dict["imaging_modality"] = "MR"
-        dataset_dict["image_access_type"] = "BY_REQUEST"
-        dataset_dict["intended_purpose"] = "placeholder"
+        # log.warning("Filling in fake values")
+
+        # FIXME: Find out how to properly do the query splitting
+        series_url = parse.urlparse(dataset_dict["biobank"])
+        dataset_dict["biobank"] = series_url.query.split('=')[1]
+        print(dataset_dict)
+        # dataset_dict["biobank"] = "CHAI-4"
+        # dataset_dict["provider"] = "CHAIMELEON"
+        # dataset_dict["order_of_magnitude"] = 1
+        # dataset_dict["country"] = "EU"
+        # dataset_dict["collection_method"] = "OTHER"
+        # dataset_dict["type"] = "ORIGINAL_DATASETS"
+        # dataset_dict["imaging_modality"] = "MR"
+        # dataset_dict["image_access_type"] = "BY_REQUEST"
+        # dataset_dict["intended_purpose"] = "placeholder"
 
         return dataset_dict
 

--- a/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
@@ -93,15 +93,6 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
                                'image_access_type', 'collection_method']
         for query_property in query_property_list:
            dataset_dict[query_property] = URL(dataset_dict[query_property]).query.get('name')
-        # dataset_dict["biobank"] = "CHAI-4"
-        # dataset_dict["provider"] = "CHAIMELEON"
-        # dataset_dict["order_of_magnitude"] = 1
-        # dataset_dict["country"] = "EU"
-        # dataset_dict["collection_method"] = "OTHER"
-        # dataset_dict["type"] = "ORIGINAL_DATASETS"
-        # dataset_dict["imaging_modality"] = "MR"
-        # dataset_dict["image_access_type"] = "BY_REQUEST"
-        # dataset_dict["intended_purpose"] = "placeholder"
 
         return dataset_dict
 
@@ -136,15 +127,6 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         query_property_list = ['geographical_coverage']
         for query_property in query_property_list:
             dataset_dict[query_property] = URL(dataset_dict[query_property]).query.get('name')
-        # # dataset_dict["biobank"] = "CHAI-4"
-        # # dataset_dict["provider"] = "CHAIMELEON"
-        # # dataset_dict["order_of_magnitude"] = 1
-        # # dataset_dict["country"] = "EU"
-        # # dataset_dict["collection_method"] = "OTHER"
-        # # dataset_dict["type"] = "ORIGINAL_DATASETS"
-        # # dataset_dict["imaging_modality"] = "MR"
-        # # dataset_dict["image_access_type"] = "BY_REQUEST"
-        # # dataset_dict["intended_purpose"] = "placeholder"
 
         return dataset_dict
 

--- a/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
@@ -74,6 +74,8 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         # dataset_dict["extras"] = []
         # dataset_dict["resources"] = []
         dataset_dict["uri"] = str(dataset_ref)
+        dataset_url = URL(str(dataset_ref))
+        catalogue_base_url = URL.build(scheme=dataset_url.scheme, host=dataset_url.host, path=dataset_url.path)
         # Basic fields
         query_property_list = ['order_of_magnitude', 'imaging_modality','geographical_coverage','type',
                                'image_access_type', 'collection_method', 'body_part_examined',
@@ -86,26 +88,24 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
             ("description", DCT.description),
             ("biobank", DCAT.inSeries),
             ("provider", DCT.publisher),
-            ("order_of_magnitude", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/order_of_magnitude")),
+            ("order_of_magnitude", URIRef(f"{catalogue_base_url}/column/order_of_magnitude")),
             ("imaging_modality", URIRef("https:/www.eucaim.org/hasImageModality")),
-            ("intended_purpose", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/intended_purpose")),
-            ("image_access_type",
-             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_type")),
+            ("geographical_coverage", DCT.spatial),
+            ("type", DCT.type),
+            ("intended_purpose", URIRef(f"{catalogue_base_url}/column/intended_purpose")),
+            ("image_access_type", URIRef(f"{catalogue_base_url}/column/image_access_type")),
             ("collection_method", URIRef("http://www.healthdcatap.org/healthCategory")),
-            ("head",
-             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/head")),
-            ("contact",
-             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/contact")),
+            ("head", URIRef(f"{catalogue_base_url}/column/head")),
+            ("contact", URIRef(f"{catalogue_base_url}/column/contact")),
             ("number_of_subjects", URIRef("http://www.healthdcatap.org/numberofUniqueIndividuals")),
             ("number_of_records", URIRef("http://www.healthdcatap.org/numberofRecords")),
             ("number_of_series", URIRef("https:/www.eucaim.org/nbrofSeries")),
             ("body_part_examined", URIRef("https:/www.eucaim.org/hasImageBodyPart")),
             ("condition", URIRef("https:/www.eucaim.org/hasCondition")),
-            ("topography", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/topography")),
+            ("topography", URIRef(f"{catalogue_base_url}/column/topography")),
             ("vendor", URIRef("https:/www.eucaim.org/hasImageVendor")),
-            ("image_year_range", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_year_range")),
-            ("image_size",
-             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_size")),
+            ("image_year_range", URIRef(f"{catalogue_base_url}/column/image_year_range")),
+            ("image_size", URIRef(f"{catalogue_base_url}/column/image_size")),
             ("sex", URIRef("https:/www.eucaim.org/hasAssociatedSex")),
             ("age_high", URIRef("http://www.healthdcatap.org/maxTypicalAge")),
             ("age_low", URIRef("http://www.healthdcatap.org/minTypicalAge")),
@@ -114,33 +114,23 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
             ("interoperability_tier", ADMS.interoperabilityLevel),
             ("provenance", DCT.provenance),
             ("intented_purpose", URIRef("https://w3id.org/dpv/dpv-skos#hasPurpose")),
-            ("terms_of_use", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/terms_of_use")),
-            ("commercial_use",
-             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/commercial_use")),
-            ("image_access_description",
-             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_description")),
-            ("image_access_fee",
-             URIRef(
-                 "http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_fee")),
-            ("image_access_uri",
-             URIRef(
-                 "http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_uri")),
-            ("publication_uri",
-             URIRef(
-                 "http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/publication_uri")),
-            ("applicable_legislation",
-             URIRef(
-                 "http://data.europa.eu/r5r/applicableLegislation")),
+            ("terms_of_use", URIRef(f"{catalogue_base_url}/column/terms_of_use")),
+            ("commercial_use", URIRef(f"{catalogue_base_url}/column/commercial_use")),
+            ("image_access_description", URIRef(f"{catalogue_base_url}/column/image_access_description")),
+            ("image_access_fee", URIRef(f"{catalogue_base_url}/column/image_access_fee")),
+            ("image_access_uri", URIRef(f"{catalogue_base_url}/column/image_access_uri")),
+            ("publication_uri", URIRef(f"{catalogue_base_url}/column/publication_uri")),
+            ("applicable_legislation", URIRef("http://data.europa.eu/r5r/applicableLegislation")),
             ("legal_basis", URIRef("https://w3id.org/dpv/dpv-skos#hasLegalBasis")),
             ("retention_period", URIRef("http://www.healthdcatap.org/retentionPeriod")),
             ("rights", DCT.rights),
-            ("hdab", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/health_data_access_body")),
+            ("hdab", URIRef(f"{catalogue_base_url}/column/health_data_access_body")),
             ("quality_label", URIRef("http://www.w3.org/ns/dqv#hasQualityAnnotation")),
             ("coding_systems", URIRef("http://www.healthdcatap.org/hasCodingSystem")),
-            ("metadata_issued", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/metadata_issued")),
+            ("metadata_issued", URIRef(f"{catalogue_base_url}/column/metadata_issued")),
             ("last_modified", DCT.modified),
             ("version", DCAT.version),
-            ("withdrawn", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/withdrawn")),
+            ("withdrawn", URIRef(f"{catalogue_base_url}/column/withdrawn")),
         )
         dataset_dict = self._extract_concept_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
 
@@ -167,13 +157,14 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         except KeyError:
             pass
 
-
         return dataset_dict
 
     def parse_datasetseries(self, dataset_dict: Dict, dataset_ref: URIRef):
         # dataset_dict["extras"] = []
         # dataset_dict["resources"] = []
         dataset_dict["uri"] = str(dataset_ref)
+        dataset_url = URL(str(dataset_ref))
+        catalogue_base_url = URL.build(scheme=dataset_url.scheme, host=dataset_url.host, path=dataset_url.path)
         # Basic fields
         key_predicate_tuple = (
             # ("id", DCT.identifier),
@@ -184,10 +175,10 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
             ("juridical_person", DCT.publisher),
             ("url", DCAT.landingPage),
             ("contact", DCAT.contactPoint),
-            ("head", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/head")),
-            ("role", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/role")),
-            ("network", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/network")),
-            ("withdrawn", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/withdrawn")),
+            ("head", URIRef(f"{catalogue_base_url}/column/head")),
+            ("role", URIRef(f"{catalogue_base_url}/column/role")),
+            ("network", URIRef(f"{catalogue_base_url}/column/network")),
+            ("withdrawn", URIRef(f"{catalogue_base_url}/column/withdrawn")),
         )
         query_property_list = ['geographical_coverage']
         dataset_dict = self._extract_concept_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
@@ -220,21 +211,23 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         # dataset_dict["extras"] = []
         # dataset_dict["resources"] = []
         dataset_dict["uri"] = str(dataset_ref)
+        dataset_url = URL(str(dataset_ref))
+        catalogue_base_url = URL.build(scheme=dataset_url.scheme, host=dataset_url.host, path=dataset_url.path)
         # Basic fields
         key_predicate_tuple = (
             ("id", FOAF.openid),
             ("name", FOAF.openid),
             ("email", FOAF.mbox),
-            ("title_before_name", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/title_before_name")),
-            ("title_after_name", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/title_after_name")),
+            ("title_before_name", URIRef(f"{catalogue_base_url}/column/title_before_name")),
+            ("title_after_name", URIRef(f"{catalogue_base_url}/column/title_after_name")),
             ("first_name", FOAF.firstName),
             ("last_name", FOAF.lastName),
             ("phone", FOAF.phone),
-            ("address", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/address")),
-            ("zip", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/zip")),
-            ("city", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/city")),
-            ("country", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/country")),
-            ("role", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/role")),
+            ("address", URIRef(f"{catalogue_base_url}/column/address")),
+            ("zip", URIRef(f"{catalogue_base_url}/column/zip")),
+            ("city", URIRef(f"{catalogue_base_url}/column/city")),
+            ("country", URIRef(f"{catalogue_base_url}/column/country")),
+            ("role", URIRef(f"{catalogue_base_url}/column/role")),
         )
         query_property_list = ['country']
         dataset_dict = self._extract_concept_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)

--- a/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
@@ -92,7 +92,7 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
              URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_type")),
             ("collection_method", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/collection_method"))
         )
-        dataset_dict = self._extract_dataset_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
+        dataset_dict = self._extract_concept_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
 
         # TODO store keywords somewhere
         # replace munge_tag to noop if there's no need to clean tags
@@ -129,7 +129,7 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
             ("withdrawn", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/withdrawn")),
         )
         query_property_list = ['geographical_coverage']
-        dataset_dict = self._extract_dataset_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
+        dataset_dict = self._extract_concept_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
 
         # # TODO store keywords somewhere
         # # replace munge_tag to noop if there's no need to clean tags
@@ -165,7 +165,7 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
             ("country", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/country")),
         )
         query_property_list = ['country']
-        dataset_dict = self._extract_dataset_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
+        dataset_dict = self._extract_concept_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
 
         dataset_dict["email"] = dataset_dict["email"].removeprefix("mailto:")
         return dataset_dict

--- a/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
@@ -92,8 +92,6 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
             ("image_access_type",
              URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_type")),
             ("collection_method", URIRef("http://www.healthdcatap.org/healthCategory")),
-            ("acronym",
-             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/acronym")),
             ("head",
              URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/head")),
             ("contact",

--- a/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/molgenis_dcat_profile.py
@@ -28,7 +28,7 @@ from .baseharvester import munge_title_to_name
 # )
 from .baseparser import RDFProfile, munge_tag, URIRefOrLiteral
 from .baseparser import (
-    DCT, DCAT
+    DCT, DCAT, ADMS, SKOS
 )
 
 log = logging.getLogger(__name__)
@@ -76,21 +76,73 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         dataset_dict["uri"] = str(dataset_ref)
         # Basic fields
         query_property_list = ['order_of_magnitude', 'imaging_modality','geographical_coverage','type',
-                               'image_access_type', 'collection_method']
+                               'image_access_type', 'collection_method', 'body_part_examined',
+                               'condition', 'topography', 'vendor', 'sex', 'interoperability_tier',
+                               'terms_of_use', 'rights', 'hdab', 'coding_systems', 'theme']
         key_predicate_tuple = (
             # ("id", DCT.identifier),
             ("name", DCT.title),
+            ("acronym", DCT.alternative),
             ("description", DCT.description),
             ("biobank", DCAT.inSeries),
             ("provider", DCT.publisher),
             ("order_of_magnitude", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/order_of_magnitude")),
             ("imaging_modality", URIRef("https:/www.eucaim.org/hasImageModality")),
-            ("geographical_coverage", DCT.spatial),
-            ("type", DCT.type),
             ("intended_purpose", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/intended_purpose")),
             ("image_access_type",
              URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_type")),
-            ("collection_method", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/collection_method"))
+            ("collection_method", URIRef("http://www.healthdcatap.org/healthCategory")),
+            ("acronym",
+             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/acronym")),
+            ("head",
+             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/head")),
+            ("contact",
+             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/contact")),
+            ("number_of_subjects", URIRef("http://www.healthdcatap.org/numberofUniqueIndividuals")),
+            ("number_of_records", URIRef("http://www.healthdcatap.org/numberofRecords")),
+            ("number_of_series", URIRef("https:/www.eucaim.org/nbrofSeries")),
+            ("body_part_examined", URIRef("https:/www.eucaim.org/hasImageBodyPart")),
+            ("condition", URIRef("https:/www.eucaim.org/hasCondition")),
+            ("topography", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/topography")),
+            ("vendor", URIRef("https:/www.eucaim.org/hasImageVendor")),
+            ("image_year_range", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_year_range")),
+            ("image_size",
+             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_size")),
+            ("sex", URIRef("https:/www.eucaim.org/hasAssociatedSex")),
+            ("age_high", URIRef("http://www.healthdcatap.org/maxTypicalAge")),
+            ("age_low", URIRef("http://www.healthdcatap.org/minTypicalAge")),
+            ("age_median", URIRef("https:/www.eucaim.org/ageMedian")),
+            ("theme", DCAT.theme),
+            ("interoperability_tier", ADMS.interoperabilityLevel),
+            ("provenance", DCT.provenance),
+            ("intented_purpose", URIRef("https://w3id.org/dpv/dpv-skos#hasPurpose")),
+            ("terms_of_use", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/terms_of_use")),
+            ("commercial_use",
+             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/commercial_use")),
+            ("image_access_description",
+             URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_description")),
+            ("image_access_fee",
+             URIRef(
+                 "http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_fee")),
+            ("image_access_uri",
+             URIRef(
+                 "http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/image_access_uri")),
+            ("publication_uri",
+             URIRef(
+                 "http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/publication_uri")),
+            ("applicable_legislation",
+             URIRef(
+                 "http://data.europa.eu/r5r/applicableLegislation")),
+            ("legal_basis", URIRef("https://w3id.org/dpv/dpv-skos#hasLegalBasis")),
+            ("retention_period", URIRef("http://www.healthdcatap.org/retentionPeriod")),
+            ("rights", DCT.rights),
+            ("hdab", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/health_data_access_body")),
+            ("quality_label", URIRef("http://www.w3.org/ns/dqv#hasQualityAnnotation")),
+            ("coding_systems", URIRef("http://www.healthdcatap.org/hasCodingSystem")),
+            ("metadata_issued", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/metadata_issued")),
+            ("last_modified", DCT.modified),
+            ("version", DCAT.version),
+            ("withdrawn", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Collections/column/withdrawn")),
         )
         dataset_dict = self._extract_concept_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)
 
@@ -108,6 +160,14 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
 
         # dataset_dict["biobank"] = URL(dataset_dict["biobank"]).query.get('id')
         dataset_dict["biobank"] = munge_title_to_name(dataset_dict["biobank"])
+        try:
+            dataset_dict["head"] = URL(dataset_dict["head"]).query.get('id')
+        except KeyError:
+            pass
+        try:
+            dataset_dict["contact"] = URL(dataset_dict["contact"]).query.get('id')
+        except KeyError:
+            pass
 
 
         return dataset_dict
@@ -120,11 +180,14 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
         key_predicate_tuple = (
             # ("id", DCT.identifier),
             ("name", DCT.title),
+            ("acronym", DCT.alternative),
             ("description", DCT.description),
             ("geographical_coverage", DCT.spatial),
             ("juridical_person", DCT.publisher),
             ("url", DCAT.landingPage),
             ("contact", DCAT.contactPoint),
+            ("head", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/head")),
+            ("role", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/role")),
             ("network", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/network")),
             ("withdrawn", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Biobanks/column/withdrawn")),
         )
@@ -147,6 +210,10 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
             dataset_dict["contact"] = URL(dataset_dict["contact"]).query.get('id')
         except KeyError:
             pass
+        try:
+            dataset_dict["head"] = URL(dataset_dict["head"]).query.get('id')
+        except KeyError:
+            pass
         dataset_dict["network"] = URL(dataset_dict["network"]).query.get('id')
 
         return dataset_dict
@@ -160,9 +227,16 @@ class MolgenisEUCAIMDCATAPProfile(RDFProfile):
             ("id", FOAF.openid),
             ("name", FOAF.openid),
             ("email", FOAF.mbox),
+            ("title_before_name", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/title_before_name")),
+            ("title_after_name", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/title_after_name")),
             ("first_name", FOAF.firstName),
             ("last_name", FOAF.lastName),
+            ("phone", FOAF.phone),
+            ("address", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/address")),
+            ("zip", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/zip")),
+            ("city", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/city")),
             ("country", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/country")),
+            ("role", URIRef("http://catalogue-eucaim.grycap.i3m.upv.es/Eucaim/api/rdf/Persons/column/role")),
         )
         query_property_list = ['country']
         dataset_dict = self._extract_concept_dict(dataset_ref, dataset_dict, key_predicate_tuple, query_property_list)

--- a/src/molgenis_fdp_harvester/ckan_harvest/processor.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/processor.py
@@ -13,6 +13,7 @@ import xml
 
 import rdflib
 import rdflib.parser
+from rdflib import FOAF
 from rdflib.namespace import Namespace, RDF, DCAT
 
 from molgenis_fdp_harvester.utils import HarvesterException
@@ -71,6 +72,26 @@ class RDFParser(RDFProcessor):
         and queries
         """
         for dataset in self.g.subjects(RDF.type, DCAT.Dataset):
+            yield dataset
+
+    def _datasetseries(self):
+        """
+        Generator that returns all DCAT datasets on the graph
+
+        Yields rdflib.term.URIRef objects that can be used on graph lookups
+        and queries
+        """
+        for dataset in self.g.subjects(RDF.type, DCAT.DatasetSeries):
+            yield dataset
+
+    def _persons(self):
+        """
+        Generator that returns all DCAT datasets on the graph
+
+        Yields rdflib.term.URIRef objects that can be used on graph lookups
+        and queries
+        """
+        for dataset in self.g.subjects(RDF.type, FOAF.Person):
             yield dataset
 
     def _catalogs(self):
@@ -156,6 +177,48 @@ class RDFParser(RDFProcessor):
             for profile_class in self._profiles:
                 profile = profile_class(self.g)
                 profile.parse_dataset(dataset_dict, dataset_ref)
+
+            dataset_dict['concept_type'] = 'dataset'
+
+            yield dataset_dict
+
+    def datasetseries(self):
+        """
+        Generator that returns CKAN datasets parsed from the RDF graph
+
+        Each dataset is passed to all the loaded profiles before being
+        yielded, so it can be further modified by each one of them.
+
+        Returns a dataset dict that can be passed to eg `package_create`
+        or `package_update`
+        """
+        for dataset_ref in self._datasetseries():
+            dataset_dict = {}
+            for profile_class in self._profiles:
+                profile = profile_class(self.g)
+                profile.parse_datasetseries(dataset_dict, dataset_ref)
+
+            dataset_dict['concept_type'] = 'datasetseries'
+
+            yield dataset_dict
+
+    def persons(self):
+        """
+        Generator that returns CKAN datasets parsed from the RDF graph
+
+        Each dataset is passed to all the loaded profiles before being
+        yielded, so it can be further modified by each one of them.
+
+        Returns a dataset dict that can be passed to eg `package_create`
+        or `package_update`
+        """
+        for dataset_ref in self._persons():
+            dataset_dict = {}
+            for profile_class in self._profiles:
+                profile = profile_class(self.g)
+                profile.parse_person(dataset_dict, dataset_ref)
+
+            dataset_dict['concept_type'] = 'person'
 
             yield dataset_dict
 

--- a/src/molgenis_fdp_harvester/ckan_harvest/processor.py
+++ b/src/molgenis_fdp_harvester/ckan_harvest/processor.py
@@ -76,7 +76,7 @@ class RDFParser(RDFProcessor):
 
     def _datasetseries(self):
         """
-        Generator that returns all DCAT datasets on the graph
+        Generator that returns all DCAT dataset series on the graph
 
         Yields rdflib.term.URIRef objects that can be used on graph lookups
         and queries
@@ -86,7 +86,7 @@ class RDFParser(RDFProcessor):
 
     def _persons(self):
         """
-        Generator that returns all DCAT datasets on the graph
+        Generator that returns all FOAF Persons on the graph
 
         Yields rdflib.term.URIRef objects that can be used on graph lookups
         and queries
@@ -96,7 +96,7 @@ class RDFParser(RDFProcessor):
 
     def _catalogs(self):
         """
-        Generator that returns all DCAT datasets on the graph
+        Generator that returns all DCAT catalogs on the graph
 
         Yields rdflib.term.URIRef objects that can be used on graph lookups
         and queries, or for get requests
@@ -184,9 +184,9 @@ class RDFParser(RDFProcessor):
 
     def datasetseries(self):
         """
-        Generator that returns CKAN datasets parsed from the RDF graph
+        Generator that returns dataset series parsed from the RDF graph
 
-        Each dataset is passed to all the loaded profiles before being
+        Each dataset series is passed to all the loaded profiles before being
         yielded, so it can be further modified by each one of them.
 
         Returns a dataset dict that can be passed to eg `package_create`
@@ -204,9 +204,9 @@ class RDFParser(RDFProcessor):
 
     def persons(self):
         """
-        Generator that returns CKAN datasets parsed from the RDF graph
+        Generator that returns FOAF persons parsed from the RDF graph
 
-        Each dataset is passed to all the loaded profiles before being
+        Each person object is passed to all the loaded profiles before being
         yielded, so it can be further modified by each one of them.
 
         Returns a dataset dict that can be passed to eg `package_create`

--- a/src/molgenis_fdp_harvester/harvester.py
+++ b/src/molgenis_fdp_harvester/harvester.py
@@ -11,6 +11,13 @@ The user creating this token requires editing permissions on the host schema.
 """
 import logging
 import os
+from pathlib import Path
+
+# Python < 3.11 does not have tomllib, but tomli provides same functionality
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 import click
 from dotenv import load_dotenv
@@ -29,11 +36,17 @@ logging.basicConfig(level="INFO")
 @click.option("--host", help="MOLGENIS host to harvest to", required=True)
 @click.option("--schema", help="Schema on MOLGENIS host to harvest to",
               required=False, default="Eucaim")
+# @click.option(
+#     "--table",
+#     help="Table of MOLGENIS host to harvest to.",
+#     required=False,
+#     default="collections"
+# )
 @click.option(
-    "--table",
-    help="Table of MOLGENIS host to harvest to.",
-    required=False,
-    default="collections"
+    "--config",
+    help="Configuration.",
+    required=True,
+    type=click.Path(exists=True, path_type=Path, readable=True)
 )
 @click.option(
     "--token", help="Authentication token of the user harvesting data.",
@@ -43,10 +56,14 @@ def cli(
     fdp: str,
     host: str,
     schema: str,
-    table: str,
+    config: click.Path,
     token: str,
 ):
-    harvest = DCATRDFHarvester([MolgenisEUCAIMDCATAPProfile], table)
+    with open(config, "rb") as fname:
+        config = tomllib.load(fname)
+    concept_table_dict = config['concept_table_link']
+
+    harvest = DCATRDFHarvester([MolgenisEUCAIMDCATAPProfile], concept_table_dict)
 
     harvest.gather_stage(fdp)
 

--- a/src/molgenis_fdp_harvester/harvester.py
+++ b/src/molgenis_fdp_harvester/harvester.py
@@ -35,8 +35,8 @@ def cli(
     harvest = DCATRDFHarvester([MolgenisEUCAIMDCATAPProfile], entity)
 
     harvest.gather_stage(fdp)
-    # for object in harvest._harvest_objects:
-    #     print(object.content)
+    for object in harvest._harvest_objects:
+        print(object.content)
     # harvest.fetch_stage(molgenis_session)
     # for object in harvest._harvest_objects:
     #     harvest.import_stage(object, molgenis_session)

--- a/src/molgenis_fdp_harvester/harvester.py
+++ b/src/molgenis_fdp_harvester/harvester.py
@@ -29,17 +29,17 @@ def cli(
     username: str,
     password: str,
 ):
-    molgenis_session = molgenis.client.Session(host)
-    molgenis_session.login(username, password)
+    # molgenis_session = molgenis.client.Session(host)
+    # molgenis_session.login(username, password)
 
     harvest = DCATRDFHarvester([MolgenisEUCAIMDCATAPProfile], entity)
 
     harvest.gather_stage(fdp)
     # for object in harvest._harvest_objects:
     #     print(object.content)
-    harvest.fetch_stage(molgenis_session)
-    for object in harvest._harvest_objects:
-        harvest.import_stage(object, molgenis_session)
+    # harvest.fetch_stage(molgenis_session)
+    # for object in harvest._harvest_objects:
+    #     harvest.import_stage(object, molgenis_session)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With this pull request the harvester can now harvest Dataset, Dataset Series and Persons from one Molgenis EMX2 catalogue to another, given that they both are configured like the EUCAIM catalogue. Networks (Catalogs) and ontologies do need to be set up in the harvesting catalogue before harvesting. The harvesting of these tables can be added to this program in the same vein als the Datasets, Dataset Series and Persons.

The unit tests that are present are still based on an old version of this package that worked with a Molgenis EMX1 catalogue. These tests should be updated.