### PR TITLE
Adds CI/CD for testing and release

### DIFF
--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2024 PNED G.I.E.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Generate Changelog
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  generate-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          fetch-depth: 0
+
+      - name: Generate changelog entry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --local user.email "Health-RI-admin@users.noreply.github.com"
+          git config --local user.name "Health-RI Admin" 
+          git pull
+          
+          CHANGELOG_FILE="CHANGELOG.md"
+          LATEST_TAG="${{ inputs.tag }}"
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | sed -n '2p')
+          
+          CHANGELOG_BRANCH="chore/$LATEST_TAG"
+          git checkout -b "$CHANGELOG_BRANCH"
+
+          echo "📢 Generating changelog for $LATEST_TAG (since $PREVIOUS_TAG)..."
+
+          COMMITS=$(git log "$PREVIOUS_TAG".."$LATEST_TAG" --no-merges --pretty=format:"%s by @%an in %h")
+
+          ADDED=""; CHANGED=""; FIXED=""; REMOVED=""; SECURITY=""
+          while IFS= read -r line; do
+            case "$line" in
+              *feat*|*implement*) ADDED+="- $line\n" ;;
+              *fix*|*bug*|*resolve*|*patch*) FIXED+="- $line\n" ;;
+              *update*|*modify*|*change*|*refactor*|*chore*) CHANGED+="- $line\n" ;;
+              *decommission*|*delete*|*remove*) REMOVED+="- $line\n" ;;
+              *security*|*vuln*|*"patch security"*) SECURITY+="- $line\n" ;;
+              *) CHANGED+="- $line\n" ;;
+            esac
+          done <<< "$COMMITS"
+
+          {
+            echo -e "## [$LATEST_TAG] - $(date +'%Y-%m-%d')\n"
+            [[ -n "$ADDED" ]] && echo -e "### Added\n$ADDED\n"
+            [[ -n "$CHANGED" ]] && echo -e "### Changed\n$CHANGED\n"
+            [[ -n "$FIXED" ]] && echo -e "### Fixed\n$FIXED\n"
+            [[ -n "$REMOVED" ]] && echo -e "### Removed\n$REMOVED\n"
+            [[ -n "$SECURITY" ]] && echo -e "### Security\n$SECURITY\n"
+          } > temp_changelog.md
+
+          if [[ ! -f "$CHANGELOG_FILE" ]]; then
+            echo -e "# Changelog\n\nAll notable changes to this project will be documented here.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\n" > "$CHANGELOG_FILE"
+          fi
+
+          sed -i '7r temp_changelog.md' "$CHANGELOG_FILE"
+          rm temp_changelog.md
+
+          git add "$CHANGELOG_FILE"
+          git commit -m "doc: update CHANGELOG.md for $LATEST_TAG"
+          git push origin "$CHANGELOG_BRANCH"
+          
+          gh pr create \
+            --title "chore: update changelog for $LATEST_TAG" \
+            --body "This PR updates the changelog for release $LATEST_TAG." \
+            --base main \
+            --draft \
+            --head "$CHANGELOG_BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2024 Stichting Health-RI
+# SPDX-FileContributor: 2024 PNED G.I.E.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Make Github release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version increment (major, minor, patch)'
+        required: true
+        default: 'patch'
+
+jobs:
+  ort:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oss-review-toolkit/ort-ci-github-action@v1
+        with:
+          allow-dynamic-versions: "true"
+          fail-on: "issues"
+          run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
+
+  versioning:
+    runs-on: ubuntu-latest
+    needs: ort
+    outputs:
+      new_tag: ${{ steps.tagging.outputs.new_tag }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set Git User Identity
+        run: |
+          git config --local user.email "Health-RI-admin@users.noreply.github.com"
+          git config --local user.name "Health-RI Admin" 
+
+      - name: Fetch Latest Tag and Increment Version
+        id: tagging
+        run: |
+          LATEST_TAG=$(git tag --sort=-creatordate | head -n 1)
+          echo "Latest tag: $LATEST_TAG"
+          
+          # Extract Major, Minor, Patch
+          IFS='.' read -r MAJOR MINOR PATCH <<<"${LATEST_TAG//v/}"
+          INCREMENT=${{ github.event.inputs.version }}
+          echo "Updating : $INCREMENT version"
+          
+          case "$INCREMENT" in
+            major) ((MAJOR++)); MINOR=0; PATCH=0 ;;
+            minor) ((MINOR++)); PATCH=0 ;;
+            patch|*) ((PATCH++)) ;;
+          esac
+
+          NEW_TAG="v$MAJOR.$MINOR.$PATCH"
+          echo "Pushing this tag: $NEW_TAG"
+          
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+          git push origin "$NEW_TAG"
+
+          echo "New tag pushed: $NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: versioning
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Generate and Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_TAG="${{ needs.versioning.outputs.new_tag }}"
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | sed -n '2p')
+
+          echo "Creating GitHub release for $LATEST_TAG from previous release $PREVIOUS_TAG"
+          
+          gh release create "$LATEST_TAG" \
+            --title "Release $LATEST_TAG" \
+            --generate-notes \
+            --notes-start-tag "$PREVIOUS_TAG"
+
+  call-generate-changelog:
+    needs: [versioning, publish-release]
+    uses: ./.github/workflows/generate_changelog.yml
+    with:
+      tag: ${{ needs.versioning.outputs.new_tag }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,0 +1,50 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Run tests for Python
+
+on:
+  push:
+  pull_request:
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        python -m pip install hatch
+    - name: Test with pytest
+      run: |
+        hatch run +py=${{ matrix.python-version }} test:cov --doctest-modules --junitxml=junit/test-results.xml
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarqube-scan-action@v5.2.0
+      if: matrix.python-version == '3.10'
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  # Summary job that depends on all test jobs
+  test-summary:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Tests failed"
+            exit 1
+          fi
+          echo "All tests passed"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -26,9 +26,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         python -m pip install hatch
-    - name: Test with pytest
-      run: |
-        hatch run +py=${{ matrix.python-version }} test:cov --doctest-modules --junitxml=junit/test-results.xml
+    # - name: Test with pytest
+    #   run: |
+    #     hatch run +py=${{ matrix.python-version }} test:cov --doctest-modules --junitxml=junit/test-results.xml
     - name: SonarCloud Scan
       uses: SonarSource/sonarqube-scan-action@v5.2.0
       if: matrix.python-version == '3.10'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -26,9 +26,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         python -m pip install hatch
-    # - name: Test with pytest
-    #   run: |
-    #     hatch run +py=${{ matrix.python-version }} test:cov --doctest-modules --junitxml=junit/test-results.xml
+    - name: Test with pytest
+      run: |
+        hatch run +py=${{ matrix.python-version }} test:cov --doctest-modules --junitxml=junit/test-results.xml
     - name: SonarCloud Scan
       uses: SonarSource/sonarqube-scan-action@v5.2.0
       if: matrix.python-version == '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ authors = [{ name = "Mark Janse", email = "mark.janse@health-ri.nl" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -55,7 +54,7 @@ cov-report = ["- coverage combine", "coverage report", "coverage xml"]
 cov = ["test-cov", "cov-report"]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.types]
 dependencies = ["mypy>=1.0.0"]
@@ -77,7 +76,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.coverage.run]
 source_pkgs = ["molgenis_fdp_harvester", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ classifiers = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/unknown/molgenis-fdp-harvester#readme"
-Issues = "https://github.com/unknown/molgenis-fdp-harvester/issues"
-Source = "https://github.com/unknown/molgenis-fdp-harvester"
+Documentation = "https://github.com/health-ri/molgenis-fdp-harvester#readme"
+Issues = "https://github.com/health-ri/molgenis-fdp-harvester/issues"
+Source = "https://github.com/health-ri/molgenis-fdp-harvester"
 
 [project.scripts]
 harvest = "molgenis_fdp_harvester.harvester:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
   "requests~=2.32.3",
   "molgenis-emx2-pyclient>=11.57.0",
   "unidecode~=1.3.8",
-  "python-dotenv~=1.0.1"
+  "python-dotenv~=1.0.1",
+  "yarl~=1.18.3"
 ]
 name = "molgenis-fdp-harvester"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ authors = [{ name = "Mark Janse", email = "mark.janse@health-ri.nl" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -54,7 +53,7 @@ cov-report = ["- coverage combine", "coverage report", "coverage xml"]
 cov = ["test-cov", "cov-report"]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.types]
 dependencies = ["mypy>=1.0.0"]
@@ -76,7 +75,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.coverage.run]
 source_pkgs = ["molgenis_fdp_harvester", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ authors = [{ name = "Mark Janse", email = "mark.janse@health-ri.nl" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -54,7 +53,7 @@ cov-report = ["- coverage combine", "coverage report", "coverage xml"]
 cov = ["test-cov", "cov-report"]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.types]
 dependencies = ["mypy>=1.0.0"]
@@ -76,7 +75,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12"]
 
 [tool.coverage.run]
 source_pkgs = ["molgenis_fdp_harvester", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ authors = [{ name = "Mark Janse", email = "mark.janse@health-ri.nl" }]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -54,7 +53,7 @@ cov-report = ["- coverage combine", "coverage report", "coverage xml"]
 cov = ["test-cov", "cov-report"]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.types]
 dependencies = ["mypy>=1.0.0"]
@@ -77,7 +76,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.coverage.run]
 source_pkgs = ["molgenis_fdp_harvester", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
   "requests-mock",
   "pytest-cov",
   "pytest-click",
-  "unidecode ~= 1.3",
+  "unidecode ~= 1.3"
 ]
 
 [[tool.hatch.envs.test.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
   "geomet",
   "requests",
   "molgenis-py-client",
-  "unidecode"
+  "unidecode",
+  "python-dotenv~=1.0.1"
 ]
 name = "molgenis-fdp-harvester"
 dynamic = ["version"]
@@ -72,6 +73,7 @@ dependencies = [
   "pytest-cov",
   "pytest-click",
   "unidecode ~= 1.3",
+  "python-dotenv~=1.0.1"
 ]
 
 [[tool.hatch.envs.test.matrix]]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.projectKey=Health-RI_molgenis-fdp-harvester
+sonar.organization=health-ri
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.version=3.10


### PR DESCRIPTION
SONAR_TOKEN is already set up.
For the release workflow an initial 'v1.0.0' tag needs to be made.

## Summary by Sourcery

Enable CI/CD by adding GitHub Actions workflows for testing, code quality scanning, automated versioning, release publishing, and changelog generation while dropping Python 3.8 support.

Enhancements:
- Remove Python 3.8 from supported versions in pyproject.toml

CI:
- Add test pipeline to run pytest, flake8, and SonarCloud scans on Python 3.9–3.11
- Add release workflow to perform OSS Review Toolkit scan, bump version tags, and create GitHub releases
- Add changelog workflow to generate CHANGELOG entries and open draft PRs for new releases