### PR TITLE
Production changes, Docker file, Github Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2024-present Health-RI
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build from (e.g. v1.2.3, main, or a commit SHA)'
+        required: true
+      tag:
+        description: 'Docker image tag (defaults to the git ref if left blank)'
+        required: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve Docker image tag
+        id: resolve_tag
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${{ github.event.inputs.ref }}"
+          fi
+          echo "image_tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.resolve_tag.outputs.image_tag }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref }}
 

--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0

--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oss-review-toolkit/ort-ci-github-action@v1
         with:
           allow-dynamic-versions: "true"
@@ -33,7 +33,7 @@ jobs:
       new_tag: ${{ steps.tagging.outputs.new_tag }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
     needs: versioning
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install GitHub CLI
         run: sudo apt-get install -y gh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: oss-review-toolkit/ort-ci-github-action@v1
         with:
           allow-dynamic-versions: "true"
@@ -33,7 +33,7 @@ jobs:
       new_tag: ${{ steps.tagging.outputs.new_tag }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -54,9 +54,9 @@ jobs:
           echo "Updating : $INCREMENT version"
           
           case "$INCREMENT" in
-            major) ((MAJOR++)); MINOR=0; PATCH=0 ;;
-            minor) ((MINOR++)); PATCH=0 ;;
-            patch|*) ((PATCH++)) ;;
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch|*) PATCH=$((PATCH + 1)) ;;
           esac
 
           NEW_TAG="v$MAJOR.$MINOR.$PATCH"
@@ -73,7 +73,7 @@ jobs:
     needs: versioning
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install GitHub CLI
         run: sudo apt-get install -y gh

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -6,6 +6,7 @@ name: Run tests for Python
 on:
   push:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 
 jobs:
@@ -16,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir .
+    pip install --no-cache-dir . && \
+    useradd --no-create-home --shell /bin/false harvester
+
+USER harvester
 
 ENTRYPOINT ["harvest"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024-present Health-RI
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+FROM python:3.12-slim
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY src/ src/
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir .
+
+ENTRYPOINT ["harvest"]

--- a/README.md
+++ b/README.md
@@ -24,21 +24,94 @@ No authentication is needed to read a public FAIR Data Point.
 Usage: harvest [OPTIONS]
 
 Options:
-  --fdp TEXT            FAIR Data Point catalog URL to harvest  [required]
-  --host TEXT           MOLGENIS host to harvest to  [required]
+  --fdp TEXT            FAIR Data Point catalog URL to harvest
+  --fdp-list PATH       Path to CSV file with columns fdp_url and fdp_id_prefix (one FDP per row)
+  --host TEXT           MOLGENIS host to harvest to
   --schema TEXT         Schema on MOLGENIS host to harvest to
-  --config PATH         Configuration.  [required]
+  --config PATH         Configuration.
   --token TEXT          Authentication token for the Molgenis catalogue of the user harvesting data.
-  --input_type TEXT     Type of endpoint to harvest from: 'rdf' or 'fdp'.  [required]
+  --input_type TEXT     Type of endpoint to harvest from: 'rdf' or 'fdp'.
   --fdp-id-prefix TEXT  FDP ID prefix used for PID construction. Optional.
   --help                Show this message and exit.
 ```
+
+Either `--fdp` (single URL) or `--fdp-list` (CSV file) must be provided; they are mutually exclusive.
+
+The `--fdp-list` CSV file must have columns `fdp_url` and `fdp_id_prefix` (one FDP per row). Whether the
+file has a header row is controlled by `fdp_list_has_header` in the TOML configuration (default: `true`).
+
 The configuration contains a linking table between the concept types, used internally in the script to separate the
 handling of the different concepts, and the table in the harvesting MOLGENIS catalogue.
 
 When `--fdp-id-prefix` is provided, it is prepended to plain-string identifiers to form the record `id`
 (e.g. `myprefix-mydataset`), and the PID service URL is used to construct the full `identifier`.
 When omitted, the plain-string identifier is used as-is for `id`, and the PID service URL is still applied.
+
+Every CLI option can also be set via an environment variable, which is the recommended approach when running
+in Docker or Kubernetes:
+
+| Environment variable | CLI option        | Required               |
+|----------------------|-------------------|------------------------|
+| `MOLGENIS_TOKEN`     | `--token`         | Yes                    |
+| `MOLGENIS_HOST`      | `--host`          | Yes                    |
+| `INPUT_TYPE`         | `--input_type`    | Yes                    |
+| `HARVEST_CONFIG`     | `--config`        | Yes                    |
+| `MOLGENIS_SCHEMA`    | `--schema`        | No (default: `Eucaim`) |
+| `FDP_URL`            | `--fdp`           | One of                 |
+| `FDP_LIST_PATH`      | `--fdp-list`      | One of                 |
+| `FDP_ID_PREFIX`      | `--fdp-id-prefix` | No                     |
+
+## Docker
+
+Pre-built images are published to the GitHub Container Registry and can be pulled with:
+
+```console
+docker pull ghcr.io/health-ri/molgenis-fdp-harvester:<tag>
+```
+
+### Running with a single FDP
+
+Mount your TOML configuration file and pass all settings via environment variables:
+
+```console
+docker run --rm \
+  -e MOLGENIS_TOKEN=<your-token> \
+  -e MOLGENIS_HOST=https://your-molgenis-host \
+  -e INPUT_TYPE=fdp \
+  -e FDP_URL=https://fdp.example.com \
+  -e HARVEST_CONFIG=/app/config.toml \
+  -v /path/to/your/config.toml:/app/config.toml \
+  ghcr.io/health-ri/molgenis-fdp-harvester:<tag>
+```
+
+### Running with a CSV list of FDPs
+
+```console
+docker run --rm \
+  -e MOLGENIS_TOKEN=<your-token> \
+  -e MOLGENIS_HOST=https://your-molgenis-host \
+  -e INPUT_TYPE=fdp \
+  -e FDP_LIST_PATH=/app/fdps.csv \
+  -e HARVEST_CONFIG=/app/config.toml \
+  -v /path/to/your/config.toml:/app/config.toml \
+  -v /path/to/your/fdps.csv:/app/fdps.csv \
+  ghcr.io/health-ri/molgenis-fdp-harvester:<tag>
+```
+
+The CSV file format:
+
+```csv
+fdp_url,fdp_id_prefix
+https://fdp1.example.com,prefix1
+https://fdp2.example.com,prefix2
+https://fdp3.example.com,
+```
+
+### Building the image locally
+
+```console
+docker build -t molgenis-fdp-harvester:local .
+```
 
 
 ## License

--- a/src/molgenis_fdp_harvester/config.py
+++ b/src/molgenis_fdp_harvester/config.py
@@ -40,6 +40,7 @@ class HarvesterConfig:
     auto_create_datasetseries: bool = True
     uri_lookup_config: Dict[str, Dict[str, str]] | None = None
     pid_service_url: str = None
+    fdp_list_has_header: bool = True
 
 
 @dataclass

--- a/src/molgenis_fdp_harvester/harvester.py
+++ b/src/molgenis_fdp_harvester/harvester.py
@@ -11,7 +11,6 @@ The user creating this token requires editing permissions on the host schema.
 """
 import csv
 import logging
-import os
 from pathlib import Path
 
 from .fdp_harvester.fdp import FDPHarvester
@@ -59,30 +58,34 @@ def read_fdp_list(csv_path: Path, has_header: bool) -> list[tuple[str, str | Non
 
 
 @click.command()
-@click.option("--fdp", help="FAIR Data Point catalog URL to harvest", required=False, default=None)
+@click.option("--fdp", envvar="FDP_URL", help="FAIR Data Point catalog URL to harvest", required=False, default=None)
 @click.option(
     "--fdp-list",
+    envvar="FDP_LIST_PATH",
     help="Path to CSV file with columns fdp_url and fdp_id_prefix (one FDP per row)",
     required=False,
     default=None,
     type=click.Path(exists=True, path_type=Path, readable=True)
 )
-@click.option("--host", help="MOLGENIS host to harvest to", required=True)
-@click.option("--schema", help="Schema on MOLGENIS host to harvest to",
+@click.option("--host", envvar="MOLGENIS_HOST", help="MOLGENIS host to harvest to", required=False, default=None)
+@click.option("--schema", envvar="MOLGENIS_SCHEMA", help="Schema on MOLGENIS host to harvest to",
               required=False, default="Eucaim")
 @click.option(
     "--config",
+    envvar="HARVEST_CONFIG",
     help="Configuration.",
-    required=True,
+    required=False,
+    default=None,
     type=click.Path(exists=True, path_type=Path, readable=True)
 )
 @click.option(
-    "--token", help="Authentication token of the user harvesting data.",
-    required=False, default=lambda: os.environ.get("MOLGENIS_TOKEN")
+    "--token", envvar="MOLGENIS_TOKEN", help="Authentication token of the user harvesting data.",
+    required=False, default=None
 )
-@click.option("--input_type", type=click.Choice(['rdf', 'fdp']), required=True)
+@click.option("--input_type", envvar="INPUT_TYPE", type=click.Choice(['rdf', 'fdp']), required=False, default=None)
 @click.option(
     "--fdp-id-prefix",
+    envvar="FDP_ID_PREFIX",
     help="FDP ID prefix used for PID construction. Only used with --fdp.",
     required=False,
     default=None
@@ -98,11 +101,23 @@ def cli(
     fdp_id_prefix: str
 ):
     """Run the harvester with the specified configuration."""
-    # Check that token is provided
+    # Check required options (not enforced at Click level to allow env var fallback)
     if not token:
         raise click.ClickException(
             "Authentication token is required. Either set the MOLGENIS_TOKEN environment "
             "variable or provide the --token option."
+        )
+    if not host:
+        raise click.ClickException(
+            "MOLGENIS host is required. Set MOLGENIS_HOST or provide --host."
+        )
+    if not config:
+        raise click.ClickException(
+            "Configuration file is required. Set HARVEST_CONFIG or provide --config."
+        )
+    if not input_type:
+        raise click.ClickException(
+            "Input type is required. Set INPUT_TYPE or provide --input_type."
         )
 
     # Validate mutual exclusivity of --fdp and --fdp-list

--- a/src/molgenis_fdp_harvester/harvester.py
+++ b/src/molgenis_fdp_harvester/harvester.py
@@ -9,6 +9,7 @@ or by directly exporting the token to the working environment
 $ export MOLGENIS_TOKEN="..."
 The user creating this token requires editing permissions on the host schema.
 """
+import csv
 import logging
 import os
 from pathlib import Path
@@ -36,8 +37,36 @@ from .config import load_config
 load_dotenv()
 logging.basicConfig(level="INFO")
 
+
+def read_fdp_list(csv_path: Path, has_header: bool) -> list[tuple[str, str | None]]:
+    """Read FDP entries from a CSV file.
+
+    Expects columns: fdp_url, fdp_id_prefix (prefix column is optional/can be blank).
+    Rows that are entirely blank are skipped.
+    """
+    entries = []
+    with open(csv_path, newline='') as f:
+        reader = csv.reader(f)
+        if has_header:
+            next(reader, None)  # consume header row
+        for row in reader:
+            if not row or not row[0].strip():
+                continue  # skip blank rows
+            fdp_url = row[0].strip()
+            fdp_id_prefix = row[1].strip() if len(row) > 1 and row[1].strip() else None
+            entries.append((fdp_url, fdp_id_prefix))
+    return entries
+
+
 @click.command()
-@click.option("--fdp", help="FAIR Data Point catalog URL to harvest", required=True)
+@click.option("--fdp", help="FAIR Data Point catalog URL to harvest", required=False, default=None)
+@click.option(
+    "--fdp-list",
+    help="Path to CSV file with columns fdp_url and fdp_id_prefix (one FDP per row)",
+    required=False,
+    default=None,
+    type=click.Path(exists=True, path_type=Path, readable=True)
+)
 @click.option("--host", help="MOLGENIS host to harvest to", required=True)
 @click.option("--schema", help="Schema on MOLGENIS host to harvest to",
               required=False, default="Eucaim")
@@ -54,12 +83,13 @@ logging.basicConfig(level="INFO")
 @click.option("--input_type", type=click.Choice(['rdf', 'fdp']), required=True)
 @click.option(
     "--fdp-id-prefix",
-    help="FDP ID prefix used for PID construction. Optional.",
+    help="FDP ID prefix used for PID construction. Only used with --fdp.",
     required=False,
     default=None
 )
 def cli(
     fdp: str,
+    fdp_list: Path,
     host: str,
     schema: str,
     config: click.Path,
@@ -75,12 +105,23 @@ def cli(
             "variable or provide the --token option."
         )
 
+    # Validate mutual exclusivity of --fdp and --fdp-list
+    if fdp and fdp_list:
+        raise click.UsageError("--fdp and --fdp-list are mutually exclusive. Provide only one.")
+    if not fdp and not fdp_list:
+        raise click.UsageError("One of --fdp or --fdp-list is required.")
+
     # Load configuration
     config_data = load_config(config)
     concept_table_dict = config_data['concept_table_link']
     harvester_config = config_data.get('harvester_config', {})
-    if fdp_id_prefix is not None:
-        harvester_config['fdp_id_prefix'] = fdp_id_prefix
+
+    # Build uniform list of (fdp_url, fdp_id_prefix) entries
+    if fdp:
+        fdp_entries = [(fdp, fdp_id_prefix)]
+    else:
+        has_header = harvester_config.get('fdp_list_has_header', True)
+        fdp_entries = read_fdp_list(fdp_list, has_header)
 
     # Define processing order for concept types
     CONCEPT_TYPE_ORDER = {
@@ -92,11 +133,13 @@ def cli(
     }
 
     with Client(url=host, schema=schema, token=token) as client:
-        # Create appropriate harvester
-        harvester = create_harvester(input_type, concept_table_dict, client, harvester_config)
+        for entry_fdp_url, entry_fdp_id_prefix in fdp_entries:
+            entry_config = dict(harvester_config)
+            if entry_fdp_id_prefix is not None:
+                entry_config['fdp_id_prefix'] = entry_fdp_id_prefix
 
-        # Execute harvesting process
-        execute_harvest(harvester, fdp, CONCEPT_TYPE_ORDER)
+            harvester = create_harvester(input_type, concept_table_dict, client, entry_config)
+            execute_harvest(harvester, entry_fdp_url, CONCEPT_TYPE_ORDER)
 
 
 def create_harvester(input_type, concept_table_dict, client, harvester_config):

--- a/src/molgenis_fdp_harvester/harvester.py
+++ b/src/molgenis_fdp_harvester/harvester.py
@@ -137,6 +137,8 @@ def cli(
     else:
         has_header = harvester_config.get('fdp_list_has_header', True)
         fdp_entries = read_fdp_list(fdp_list, has_header)
+        if not fdp_entries:
+            raise click.ClickException(f"FDP list file '{fdp_list}' contains no valid entries.")
 
     # Define processing order for concept types
     CONCEPT_TYPE_ORDER = {

--- a/src/molgenis_fdp_harvester/rdf_harvester/rdf.py
+++ b/src/molgenis_fdp_harvester/rdf_harvester/rdf.py
@@ -162,7 +162,6 @@ class DCATRDFHarvester(DCATHarvester):
         if (concept_type == 'dataset'
                 and self.harvester_config.get('auto_create_datasetseries', False)
                 and ('in_series' not in concept_dict or not concept_dict['in_series'])):
-            print(concept_dict)
             # Track this dataset for later datasetseries creation
             self._datasets_without_datasetseries.append({
                 'dataset_name': concept_dict.get('title'),

--- a/tests/test_harvester_cli.py
+++ b/tests/test_harvester_cli.py
@@ -3,13 +3,15 @@
 # Test that the dotenv is picked up correctly
 # Test that the correct harvester is created in create_harvester, and that ValueError is raised if the 'else' branch is triggered.
 
+import io
 import os
 import pytest
 import tempfile
-from unittest.mock import Mock, patch, MagicMock
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock, call
 from click.testing import CliRunner
 
-from molgenis_fdp_harvester.harvester import cli, create_harvester
+from molgenis_fdp_harvester.harvester import cli, create_harvester, read_fdp_list
 from molgenis_emx2_pyclient import Client
 
 
@@ -220,3 +222,229 @@ def test_create_harvester_invalid_type(concept_table_dict, harvester_config):
 
     assert "Unknown input_type" in str(exc_info.value), \
         f"Expected error message about unknown input_type, got: {exc_info.value}"
+
+
+# ---------------------------------------------------------------------------
+# Multi-FDP CSV tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def temp_config_file_no_header():
+    """Config file with fdp_list_has_header = false"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.toml', delete=False) as f:
+        f.write("""[concept_table_link]
+dataset = "collections"
+datasetseries = "biobanks"
+kind = "kind"
+publisher = "publisher"
+provenancestatement = "provenancestatement"
+
+[harvester_config]
+auto_create_datasetseries = true
+fdp_list_has_header = false
+""")
+        config_path = f.name
+
+    yield config_path
+
+    os.unlink(config_path)
+
+
+@pytest.fixture
+def temp_fdp_list_with_header():
+    """CSV file with header row and two FDP entries"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        f.write("fdp_url,fdp_id_prefix\n")
+        f.write("http://fdp1.example.com,prefix1\n")
+        f.write("http://fdp2.example.com,prefix2\n")
+        csv_path = f.name
+
+    yield csv_path
+
+    os.unlink(csv_path)
+
+
+@pytest.fixture
+def temp_fdp_list_without_header():
+    """CSV file without header row and two FDP entries"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        f.write("http://fdp1.example.com,prefix1\n")
+        f.write("http://fdp2.example.com,prefix2\n")
+        csv_path = f.name
+
+    yield csv_path
+
+    os.unlink(csv_path)
+
+
+def test_fdp_and_fdp_list_mutually_exclusive(temp_config_file, temp_fdp_list_with_header, monkeypatch):
+    """Providing both --fdp and --fdp-list should fail with exit code 2"""
+    runner = CliRunner()
+    monkeypatch.setenv('MOLGENIS_TOKEN', 'token')
+
+    result = runner.invoke(cli, [
+        '--fdp', 'http://example.com',
+        '--fdp-list', temp_fdp_list_with_header,
+        '--host', 'http://localhost:8080',
+        '--config', temp_config_file,
+        '--input_type', 'rdf',
+    ])
+
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.output
+
+
+def test_neither_fdp_nor_fdp_list_raises_error(temp_config_file, monkeypatch):
+    """Providing neither --fdp nor --fdp-list should fail with exit code 2"""
+    runner = CliRunner()
+    monkeypatch.setenv('MOLGENIS_TOKEN', 'token')
+
+    result = runner.invoke(cli, [
+        '--host', 'http://localhost:8080',
+        '--config', temp_config_file,
+        '--input_type', 'rdf',
+    ])
+
+    assert result.exit_code == 2
+    assert "--fdp" in result.output or "required" in result.output.lower()
+
+
+def test_fdp_list_with_header(temp_config_file, temp_fdp_list_with_header, mock_harvester_patches, monkeypatch):
+    """CSV with header row: execute_harvest called once per data row"""
+    runner = CliRunner()
+    monkeypatch.setenv('MOLGENIS_TOKEN', 'token')
+
+    result = runner.invoke(cli, [
+        '--fdp-list', temp_fdp_list_with_header,
+        '--host', 'http://localhost:8080',
+        '--config', temp_config_file,
+        '--input_type', 'fdp',
+    ])
+
+    assert result.exit_code == 0, f"Unexpected failure: {result.output}"
+    assert mock_harvester_patches['execute_harvest'].call_count == 2
+
+    calls = mock_harvester_patches['execute_harvest'].call_args_list
+    urls = [c[0][1] for c in calls]
+    assert 'http://fdp1.example.com' in urls
+    assert 'http://fdp2.example.com' in urls
+
+
+def test_fdp_list_without_header(temp_config_file_no_header, temp_fdp_list_without_header, mock_harvester_patches, monkeypatch):
+    """CSV without header row: first row treated as data, execute_harvest called twice"""
+    runner = CliRunner()
+    monkeypatch.setenv('MOLGENIS_TOKEN', 'token')
+
+    result = runner.invoke(cli, [
+        '--fdp-list', temp_fdp_list_without_header,
+        '--host', 'http://localhost:8080',
+        '--config', temp_config_file_no_header,
+        '--input_type', 'fdp',
+    ])
+
+    assert result.exit_code == 0, f"Unexpected failure: {result.output}"
+    assert mock_harvester_patches['execute_harvest'].call_count == 2
+
+
+def test_fdp_list_per_row_prefix(temp_config_file, temp_fdp_list_with_header, mock_harvester_patches, monkeypatch):
+    """Each CSV row's fdp_id_prefix is passed to create_harvester as entry_config"""
+    runner = CliRunner()
+    monkeypatch.setenv('MOLGENIS_TOKEN', 'token')
+
+    result = runner.invoke(cli, [
+        '--fdp-list', temp_fdp_list_with_header,
+        '--host', 'http://localhost:8080',
+        '--config', temp_config_file,
+        '--input_type', 'fdp',
+    ])
+
+    assert result.exit_code == 0, f"Unexpected failure: {result.output}"
+    assert mock_harvester_patches['create_harvester'].call_count == 2
+
+    calls = mock_harvester_patches['create_harvester'].call_args_list
+    prefixes = [c[0][3].get('fdp_id_prefix') for c in calls]
+    assert 'prefix1' in prefixes
+    assert 'prefix2' in prefixes
+
+
+def test_fdp_list_row_without_prefix(temp_config_file, mock_harvester_patches, monkeypatch):
+    """A CSV row with no prefix column should not set fdp_id_prefix in config"""
+    runner = CliRunner()
+    monkeypatch.setenv('MOLGENIS_TOKEN', 'token')
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        f.write("fdp_url,fdp_id_prefix\n")
+        f.write("http://fdp1.example.com,\n")  # blank prefix
+        csv_path = f.name
+
+    try:
+        result = runner.invoke(cli, [
+            '--fdp-list', csv_path,
+            '--host', 'http://localhost:8080',
+            '--config', temp_config_file,
+            '--input_type', 'fdp',
+        ])
+
+        assert result.exit_code == 0, f"Unexpected failure: {result.output}"
+        call_args = mock_harvester_patches['create_harvester'].call_args
+        entry_config = call_args[0][3]
+        assert 'fdp_id_prefix' not in entry_config
+    finally:
+        os.unlink(csv_path)
+
+
+def test_single_fdp_backward_compat(base_cli_args, mock_harvester_patches, monkeypatch):
+    """--fdp still works and execute_harvest is called exactly once"""
+    runner = CliRunner()
+    monkeypatch.setenv('MOLGENIS_TOKEN', 'token')
+
+    result = runner.invoke(cli, base_cli_args)
+
+    assert result.exit_code == 0, f"Unexpected failure: {result.output}"
+    assert mock_harvester_patches['execute_harvest'].call_count == 1
+    call_url = mock_harvester_patches['execute_harvest'].call_args[0][1]
+    assert call_url == 'http://example.com/fdp'
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for read_fdp_list helper
+# ---------------------------------------------------------------------------
+
+def test_read_fdp_list_with_header(tmp_path):
+    """read_fdp_list correctly skips header and returns data rows"""
+    csv_file = tmp_path / "fdps.csv"
+    csv_file.write_text("fdp_url,fdp_id_prefix\nhttp://a.com,pA\nhttp://b.com,pB\n")
+
+    result = read_fdp_list(csv_file, has_header=True)
+
+    assert result == [('http://a.com', 'pA'), ('http://b.com', 'pB')]
+
+
+def test_read_fdp_list_without_header(tmp_path):
+    """read_fdp_list treats first row as data when has_header=False"""
+    csv_file = tmp_path / "fdps.csv"
+    csv_file.write_text("http://a.com,pA\nhttp://b.com,pB\n")
+
+    result = read_fdp_list(csv_file, has_header=False)
+
+    assert result == [('http://a.com', 'pA'), ('http://b.com', 'pB')]
+
+
+def test_read_fdp_list_missing_prefix_column(tmp_path):
+    """read_fdp_list returns None for prefix when column is absent or blank"""
+    csv_file = tmp_path / "fdps.csv"
+    csv_file.write_text("fdp_url,fdp_id_prefix\nhttp://a.com,\nhttp://b.com\n")
+
+    result = read_fdp_list(csv_file, has_header=True)
+
+    assert result == [('http://a.com', None), ('http://b.com', None)]
+
+
+def test_read_fdp_list_skips_blank_rows(tmp_path):
+    """read_fdp_list skips entirely blank rows"""
+    csv_file = tmp_path / "fdps.csv"
+    csv_file.write_text("fdp_url,fdp_id_prefix\nhttp://a.com,pA\n\nhttp://b.com,pB\n")
+
+    result = read_fdp_list(csv_file, has_header=True)
+
+    assert result == [('http://a.com', 'pA'), ('http://b.com', 'pB')]

--- a/tests/test_harvester_cli.py
+++ b/tests/test_harvester_cli.py
@@ -199,6 +199,34 @@ def test_cli_with_only_required_parameters(base_cli_args, mock_harvester_patches
         "Token should be picked up from environment"
 
 
+def test_cli_all_env_vars(temp_config_file, mock_harvester_patches, monkeypatch):
+    """CLI works when all arguments are supplied via environment variables, with no CLI flags."""
+    runner = CliRunner()
+
+    monkeypatch.setenv('MOLGENIS_TOKEN', 'env_token')
+    monkeypatch.setenv('MOLGENIS_HOST', 'http://env-host:8080')
+    monkeypatch.setenv('MOLGENIS_SCHEMA', 'EnvSchema')
+    monkeypatch.setenv('HARVEST_CONFIG', temp_config_file)
+    monkeypatch.setenv('INPUT_TYPE', 'rdf')
+    monkeypatch.setenv('FDP_URL', 'http://env-fdp.example.com')
+
+    result = runner.invoke(cli, [])
+
+    assert result.exit_code == 0, f"CLI failed with exit code {result.exit_code}:\nOutput: {result.output}"
+
+    mock_harvester_patches['client_class'].assert_called_once()
+    client_kwargs = mock_harvester_patches['client_class'].call_args.kwargs
+    assert client_kwargs['url'] == 'http://env-host:8080'
+    assert client_kwargs['schema'] == 'EnvSchema'
+    assert client_kwargs['token'] == 'env_token'
+
+    mock_harvester_patches['create_harvester'].assert_called_once()
+    assert mock_harvester_patches['create_harvester'].call_args[0][0] == 'rdf'
+
+    mock_harvester_patches['execute_harvest'].assert_called_once()
+    assert mock_harvester_patches['execute_harvest'].call_args[0][1] == 'http://env-fdp.example.com'
+
+
 @pytest.mark.parametrize("input_type,expected_class", [
     ('rdf', 'DCATRDFHarvester'),
     ('fdp', 'FDPHarvester'),
@@ -448,3 +476,26 @@ def test_read_fdp_list_skips_blank_rows(tmp_path):
     result = read_fdp_list(csv_file, has_header=True)
 
     assert result == [('http://a.com', 'pA'), ('http://b.com', 'pB')]
+
+
+def test_fdp_list_empty_raises_error(temp_config_file, monkeypatch):
+    """An --fdp-list file with no valid entries should fail with an error"""
+    runner = CliRunner()
+    monkeypatch.setenv('MOLGENIS_TOKEN', 'token')
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        f.write("fdp_url,fdp_id_prefix\n")  # header only, no data rows
+        csv_path = f.name
+
+    try:
+        result = runner.invoke(cli, [
+            '--fdp-list', csv_path,
+            '--host', 'http://localhost:8080',
+            '--config', temp_config_file,
+            '--input_type', 'fdp',
+        ])
+
+        assert result.exit_code != 0
+        assert "no valid entries" in result.output.lower() or "no valid entries" in str(result.exception).lower()
+    finally:
+        os.unlink(csv_path)


### PR DESCRIPTION
- A batch mode to support loading FDP URLs and ID prefixes from file.
- Change in CLI to load input arguments from environment variables.
- A Dockerfile
- A Github Actions to build and push Docker images to GHCR

## Summary by Sourcery

Add batch harvesting support, environment-based configuration, and containerisation/CI improvements for the FDP harvester CLI.

New Features:
- Allow harvesting multiple FDP instances from a CSV list of URLs and optional ID prefixes, with configuration of header handling.
- Support configuring all CLI options via environment variables for easier non-interactive and containerised use.
- Provide a Docker image definition and workflow to build and publish images to GitHub Container Registry.

Enhancements:
- Refine CLI argument validation to require host, config, input type, and authentication token even when using environment variables.
- Update README with usage instructions for batch FDP harvesting, environment variables, and Docker-based execution.
- Remove leftover debug output from the RDF harvester implementation.

CI:
- Add a manual workflow to build and push Docker images to GHCR.
- Update existing GitHub Actions workflows to use newer checkout action versions and fix shell arithmetic for semantic version bumping.
- Narrow test workflow pull_request triggers to specific event types.