### PR TITLE
fix: bump version to 0.1.0

### DIFF
--- a/src/molgenis_fdp_harvester/__about__.py
+++ b/src/molgenis_fdp_harvester/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present Mark Janse <mark.janse@health-ri.nl>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-__version__ = "0.0.1"
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the recorded project version from 0.0.1 to 0.1.0 in the package metadata.