### PR TITLE
fix(ci): update release workflow when no initial tag exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,12 @@ jobs:
         run: |
           LATEST_TAG=$(git tag --sort=-creatordate | head -n 1)
           echo "Latest tag: $LATEST_TAG"
-          
+
+          # Default to 0.0.0 if no tag exists
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
+
           # Extract Major, Minor, Patch
           IFS='.' read -r MAJOR MINOR PATCH <<<"${LATEST_TAG//v/}"
           INCREMENT=${{ github.event.inputs.version }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update release workflow to default the latest tag to v0.0.0 when no tag exists before computing the next version.